### PR TITLE
Carla/fix latex

### DIFF
--- a/src/symmetries/analysis/lie_symmetry_analysis.py
+++ b/src/symmetries/analysis/lie_symmetry_analysis.py
@@ -2,7 +2,6 @@
 simplifying the equations."""
 import warnings
 
-from symmetries.utils.latex import latex_det_eqn
 from symmetries.objects.system import Model
 from symmetries.objects.determining_equations import DeterminingEquations
 
@@ -14,7 +13,6 @@ def point_symmetries(
     independent_variables: list,
     dependent_variables: list,
     constants: list,
-    latex: bool = False
 ):
     # Ignore deprecated warnings. This was implemented to ignore sympy's warning when using a
     # a matrix to show the determining equations.
@@ -29,7 +27,7 @@ def point_symmetries(
         order=order,
         **variables
     )
-    # This section of the code generates the infitesimals for all the independent variables and
+    # This section of the code generates the infinitesimals for all the independent variables and
     # dependent variables.
     #
     model.infinitesimals_generator()

--- a/src/symmetries/objects/determining_equations.py
+++ b/src/symmetries/objects/determining_equations.py
@@ -416,7 +416,7 @@ class DeterminingEquations(SystemOfEquations):
 
         return matrix
 
-    def print_latex(self):
+    def print_latex(self)-> None:
         backslash_char = "\\"
         latex_dict = {}
         var_list = []
@@ -448,7 +448,4 @@ class DeterminingEquations(SystemOfEquations):
             var_list,
             constants,
         ).format_determining_equations()
-        
-        latex_code = latex_code.replace("+-", "-")
         print(latex_code)
-        return latex_dict

--- a/src/symmetries/objects/determining_equations.py
+++ b/src/symmetries/objects/determining_equations.py
@@ -425,10 +425,11 @@ class DeterminingEquations(SystemOfEquations):
             #
             var = str(variable)
             if len(str(var)) > 1:
-                latex_dict[f'xi{var}'] = f'xi^{"{"}{backslash_char}{variable}'
+                latex_dict[f'xi{var}'] = f'xi^{"{"}{backslash_char}{var}{"}"}'
             else:
-                latex_dict[f'xi{var}'] = f'xi^{"{"}{variable}{"}"}'
+                latex_dict[f'xi{var}'] = f'xi^{"{"}{var}{"}"}'
             var_list.append(var)
+
         for variable in self.dependent_variables:
             # If the string length of the variable is bigger than one assumes it is a greek letter.
             #
@@ -438,10 +439,16 @@ class DeterminingEquations(SystemOfEquations):
             else:
                 latex_dict[f'eta{var}'] = f'eta^{"{"}{var}{"}"}'
             var_list.append(var)
-        constants = []
-        for cte in self.constants:
-            constants.append(str(cte))
+
+        constants = [str(cte) for cte in self.constants]
+
         latex_code = latex_det_eqn(
-            self.determining_equations, latex_dict, var_list, constants)
+            self.determining_equations,
+            latex_dict,
+            var_list,
+            constants,
+        )
+        
         latex_code = latex_code.replace("+-", "-")
-        return print(latex_code)
+        print(latex_code)
+        return latex_dict

--- a/src/symmetries/objects/determining_equations.py
+++ b/src/symmetries/objects/determining_equations.py
@@ -424,7 +424,7 @@ class DeterminingEquations(SystemOfEquations):
             # If the string length of the variable is bigger than one assumes it is a greek letter.
             #
             var = str(variable)
-            if len(str(var)) > 1:
+            if len(var) > 1:
                 latex_dict[f'xi{var}'] = f'xi^{"{"}{backslash_char}{var}{"}"}'
             else:
                 latex_dict[f'xi{var}'] = f'xi^{"{"}{var}{"}"}'
@@ -434,7 +434,7 @@ class DeterminingEquations(SystemOfEquations):
             # If the string length of the variable is bigger than one assumes it is a greek letter.
             #
             var = str(variable).split("(")[0]
-            if len(str(var)) > 1:
+            if len(var) > 1:
                 latex_dict[f'eta{var}'] = f'eta^{"{"}{backslash_char}{var}{"}"}'
             else:
                 latex_dict[f'eta{var}'] = f'eta^{"{"}{var}{"}"}'
@@ -447,7 +447,7 @@ class DeterminingEquations(SystemOfEquations):
             latex_dict,
             var_list,
             constants,
-        ).latex_det_eqn()
+        ).format_determining_equations()
         
         latex_code = latex_code.replace("+-", "-")
         print(latex_code)

--- a/src/symmetries/objects/determining_equations.py
+++ b/src/symmetries/objects/determining_equations.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 import sympy
 import numpy as np
 from symmetries.utils.algebra import key_ordering, str_to_dict, is_zero
-from symmetries.utils.latex import latex_det_eqn
+from symmetries.utils.latex import Latex
 from symmetries.utils.symbolic import sym_det_eqn, parse_variables
 from .system_of_equations import SystemOfEquations
 from .system import Model
@@ -442,12 +442,12 @@ class DeterminingEquations(SystemOfEquations):
 
         constants = [str(cte) for cte in self.constants]
 
-        latex_code = latex_det_eqn(
+        latex_code = Latex(
             self.determining_equations,
             latex_dict,
             var_list,
             constants,
-        )
+        ).latex_det_eqn()
         
         latex_code = latex_code.replace("+-", "-")
         print(latex_code)

--- a/src/symmetries/objects/latex.py
+++ b/src/symmetries/objects/latex.py
@@ -47,13 +47,13 @@ class Latex():
         derivatives = term['derivatives']
         term_latex = ''
         if one_term:
-            coeff = ''
+            coefficient = ''
         else:
-            coeff = str(term['coefficient'])
-            if coeff == '-1':
-                coeff = "-"
-            elif coeff == '1':
-                coeff = ""
+            coefficient = str(term['coefficient'])
+            if coefficient == '-1':
+                coefficient = "-"
+            elif coefficient == '1':
+                coefficient = ""
 
             for cte, n in zip(self.symbolic_constants, term['constants']):
                 cte = str(cte)
@@ -66,7 +66,7 @@ class Latex():
                     term_latex += cte + '^' + str(n)
 
         D = self.format_derivatives(derivatives, variable)
-        return coeff + term_latex + D
+        return coefficient + term_latex + D
 
     def format_derivatives(self, derivatives: list, variable: str):
         """Given a list of derivatives executes all the derivatives on the variable.

--- a/src/symmetries/objects/latex_class.py
+++ b/src/symmetries/objects/latex_class.py
@@ -1,5 +1,0 @@
-class Latex():
-    def __init__(self, determining_equations:dict, independent_variables:list,
-                 dependent_variables:list, constants:list):
-        self.equations = determining_equations
-        self.variables = independent_variables

--- a/src/symmetries/utils/latex.py
+++ b/src/symmetries/utils/latex.py
@@ -50,6 +50,10 @@ class Latex():
             coeff = ''
         else:
             coeff = str(term['coefficient'])
+            if coeff == '-1':
+                coeff = "-"
+            if coeff == '1':
+                coeff = ""
             for cte, n in zip(self.symbolic_constants, term['constants']):
                 if len(str(cte)) > 1:
                     if n == 1:

--- a/src/symmetries/utils/latex.py
+++ b/src/symmetries/utils/latex.py
@@ -25,7 +25,7 @@ class Latex():
 
         diff = len(self.constants) - len(self.variables)
         alpha_id = [f'alpha_{idx}' for idx in range(diff)]
-        self.symbolic_constants = self.variables + alpha_id
+        self.symbolic_constants = constants+ self.variables + alpha_id
 
     def format_equation_term(self, term: dict, one_term: bool):
         """Given a dictionary it returns the symbolic equivalent. It drops all constants
@@ -126,4 +126,4 @@ class Latex():
         for equation in self.determining_equations.values():
             latex_system_of_eqns += self.format_equation(
                 equation) + "\\" + "\\" + "\n"
-        return latex_system_of_eqns
+        return latex_system_of_eqns.replace("+-", "-")

--- a/src/symmetries/utils/latex.py
+++ b/src/symmetries/utils/latex.py
@@ -1,52 +1,53 @@
-"""Module containing functions for printing in Latex form"""
+"""Module containing functions for printing equations in Latex form"""
 
 
 class Latex():
 
-    def __init__(self, det_eqn, var_dict: dict, var_list: list, constants: list):
+    def __init__(self, determining_equations, var_dict: dict, variables: list, constants: list):
         """_summary_
 
         Parameters
         ----------
-        det_eqn : _type_
+        determining_equations : _type_
             _description_
-        var_dict : [dict]
+        var_dict : dict
             dictionary translating the variable name to latex format
-        var_list : [list]
-            list with all variables (independent and dependant)list with the constants written in latex format
-        constants : [list]
+        variables : list
+            list with all variables (independent and dependant) with the constants
+            written in latex format
+        constants : list
             list containing all constants
         """
-        self.det_eqn = det_eqn
+        self.determining_equations = determining_equations
         self.var_dict = var_dict
-        self.var_list = var_list
+        self.variables = variables
         self.constants = constants
 
-    def dict_to_latex(self, term: dict, sym_cte_list: list, one_term: bool):
-        """Given a dictionary it returns the symbolic equivalent. It drops all constants if it is  just one term.
+    def dict_to_latex(self, term: dict, symbolic_constants: list, one_term: bool):
+        """Given a dictionary it returns the symbolic equivalent. It drops all constants
+        if it is just one term.
 
         Parameters
         ----------
-        term : [dict]
+        term : dict
             dictionary containing the information of the term
-        sym_cte_list : [list]
+        symbolic_constants : list
             [description]
-        one_term : [boolean]
+        one_term : bool
             True if it is the only term in the equation
 
         Returns
         -------
-        [str]
+        str
             The latex code to write the term. 
         """
-        var = self.var_dict[term['variable']]
-        list_devs = term['derivatives']
-        cte_power = zip(sym_cte_list, term['constants'])
+        variable = self.var_dict[term['variable']]
+        derivatives = term['derivatives']
         a = ''
         if one_term:
             coeff = ''
         else:
-            for cte, n in cte_power:
+            for cte, n in zip(symbolic_constants, term['constants']):
                 if len(str(cte)) > 1:
                     if n == 1:
                         a += "\\" + str(cte)
@@ -58,74 +59,72 @@ class Latex():
                     if n > 1:
                         a += str(cte) + '^' + str(n)
             coeff = str(term['coefficient'])
-        D = self.latex_derivative(list_devs, var)
-        latex_term = coeff + a + D
-        return latex_term
+        D = self.format_derivatives(derivatives, variable)
+        return coeff + a + D
 
-    def latex_derivative(self, list_devs: list, var: str):
+    def format_derivatives(self, derivatives: list, variable: str):
         """Given a list of derivatives executes all the derivatives on the variable.
 
         Parameters
         ----------
-        list_devs : [list]
-            list of ints containing the order of the derivative with respect to the variable var_lists.
-        var : [str]
+        derivatives : list
+            list of integers containing the order of the derivative with respect to the
+            variable
+        variable : str
             variable to be differentiate
 
         Returns
         -------
-        [str]
+        str
             latex code for the derivative.
         """
-        D_v = zip(list_devs, self.var_list)
-        var_str = '\\' + var
-        for D, v in D_v:
+        var_str = '\\' + variable
+        for D, var in zip(derivatives, self.variables):
             for _ in range(D):
-                if len(str(v)) > 1:
+                if len(str(variable)) > 1:
                     if '_' in var_str:
-                        var_str = var_str + "\\" + v
+                        var_str += "\\" + var
                     else:
-                        var_str = var_str + '_' + '{' + "\\" + v
+                        var_str += '_' + '{' + "\\" + var
                 else:
                     if '_' in var_str:
-                        var_str = var_str + v
+                        var_str += var
                     else:
-                        var_str = var_str + '_' + '{' + v
+                        var_str += '_' + '{' + var
         return var_str + '}'
 
-    def latex_eqn_code(self, eqn: dict) -> str:
+    def format_equation(self, equation: dict) -> str:
         """This code generates the latex string format of the determinant equations
 
         Parameters
         ----------
-        eqn : [dictionary]
+        equation : dict
             dictionary containing all the determinant equations
 
         Returns
         -------
-        [string]
+        str
             single string with all the equations typed in latex format
         """
+        diff = len(self.constants) - len(self.variables)
+        alpha_id = [f'alpha_{idx}' for idx in range(diff)]
+        symbolic_constants = self.variables + alpha_id
 
-        sym_cte_list = [var for var in self.var_list]
-        for idx in range(len(self.constants) - len(self.var_list)):
-            sym_cte_list.append('alpha_' + str(idx))
+        latex_equation = ''
+        one_term = (len(equation) == 1)
+        for term in equation:
+            latex_equation += self.dict_to_latex(term, symbolic_constants, one_term) + '+'
+        return latex_equation[:-1] + '=0'
 
-        A = ''
-        for term in eqn:
-            one_term = (len(eqn) == 1)
-            A += self.dict_to_latex(term, sym_cte_list, one_term) + '+'
-        return A[:-1] + '=0'
-
-    def latex_det_eqn(self):
+    def format_determining_equations(self):
         """Gives the latex code version of remaining determining equation.
 
         Returns
         -------
-        [string]
+        str
             single string with all the equations typed in latex format
         """
-        latex_code = ''
-        for eqn in self.det_eqn.values():
-            latex_code += self.latex_eqn_code(eqn) + "\\" + "\\" + "\n"
-        return latex_code
+        latex_system_of_eqns = ''
+        for equation in self.determining_equations.values():
+            latex_system_of_eqns += self.format_equation(equation) + "\\" + "\\" + "\n"
+        return latex_system_of_eqns

--- a/src/symmetries/utils/latex.py
+++ b/src/symmetries/utils/latex.py
@@ -86,17 +86,15 @@ class Latex():
         """
         var_str = '\\' + variable
         for D, var in zip(derivatives, self.variables):
+            var = str(var)
             for _ in range(D):
-                if len(str(variable)) > 1:
-                    if '_' in var_str:
-                        var_str += "\\" + var
-                    else:
-                        var_str += '_' + '{' + "\\" + var + '}'
+                if len(var) > 1:
+                    var = "\\" + var
+
+                if '_' in var_str:
+                    var_str +=  '{' + var + '}'
                 else:
-                    if '_' in var_str:
-                        var_str += var
-                    else:
-                        var_str += '_' + '{' + var + '}'
+                    var_str += '_' + '{' + var + '}'
         return var_str
 
     def format_equation(self, equation: dict) -> str:

--- a/src/symmetries/utils/latex.py
+++ b/src/symmetries/utils/latex.py
@@ -52,19 +52,19 @@ class Latex():
             coeff = str(term['coefficient'])
             if coeff == '-1':
                 coeff = "-"
-            if coeff == '1':
+            elif coeff == '1':
                 coeff = ""
+
             for cte, n in zip(self.symbolic_constants, term['constants']):
-                if len(str(cte)) > 1:
-                    if n == 1:
-                        term_latex += "\\" + str(cte)
-                    if n > 1:
-                        term_latex += "\\" + str(cte) + '^' + str(n)
-                else:
-                    if n == 1:
-                        term_latex += str(cte)
-                    if n > 1:
-                        term_latex += str(cte) + '^' + str(n)
+                cte = str(cte)
+                if len(cte) > 1:
+                    cte = "\\" + cte
+
+                if n == 1:
+                    term_latex += cte
+                elif n > 1:
+                    term_latex += cte + '^' + str(n)
+
         D = self.format_derivatives(derivatives, variable)
         return coeff + term_latex + D
 

--- a/src/symmetries/utils/latex.py
+++ b/src/symmetries/utils/latex.py
@@ -41,11 +41,11 @@ class Latex():
         Returns
         -------
         str
-            The latex code to write the term. 
+            latex code to write the term
         """
         variable = self.var_dict[term['variable']]
         derivatives = term['derivatives']
-        a = ''
+        term_latex = ''
         if one_term:
             coeff = ''
         else:
@@ -53,16 +53,16 @@ class Latex():
             for cte, n in zip(self.symbolic_constants, term['constants']):
                 if len(str(cte)) > 1:
                     if n == 1:
-                        a += "\\" + str(cte)
+                        term_latex += "\\" + str(cte)
                     if n > 1:
-                        a += "\\" + str(cte) + '^' + str(n)
+                        term_latex += "\\" + str(cte) + '^' + str(n)
                 else:
                     if n == 1:
-                        a += str(cte)
+                        term_latex += str(cte)
                     if n > 1:
-                        a += str(cte) + '^' + str(n)
+                        term_latex += str(cte) + '^' + str(n)
         D = self.format_derivatives(derivatives, variable)
-        return coeff + a + D
+        return coeff + term_latex + D
 
     def format_derivatives(self, derivatives: list, variable: str):
         """Given a list of derivatives executes all the derivatives on the variable.
@@ -78,7 +78,7 @@ class Latex():
         Returns
         -------
         str
-            latex code for the derivative.
+            latex code for the derivatives
         """
         var_str = '\\' + variable
         for D, var in zip(derivatives, self.variables):
@@ -101,12 +101,12 @@ class Latex():
         Parameters
         ----------
         equation : dict
-            dictionary containing all the determinant equations
+            dictionary containing a determinant equation
 
         Returns
         -------
         str
-            single string with all the equations typed in latex format
+            string with all terms of a single equation typed in latex format
         """
         latex_equation = ''
         one_term = (len(equation) == 1)

--- a/src/symmetries/utils/latex.py
+++ b/src/symmetries/utils/latex.py
@@ -2,28 +2,32 @@
 
 
 class Latex():
+    """Latex class"""
 
     def __init__(self, determining_equations, var_dict: dict, variables: list, constants: list):
-        """_summary_
+        """Constructor
 
         Parameters
         ----------
-        determining_equations : _type_
+        determining_equations : dict
             _description_
         var_dict : dict
             dictionary translating the variable name to latex format
         variables : list
-            list with all variables (independent and dependant) with the constants
-            written in latex format
+            list with all variables (independent and dependant) written in latex format
         constants : list
-            list containing all constants
+            list containing all constants in string format
         """
         self.determining_equations = determining_equations
         self.var_dict = var_dict
         self.variables = variables
         self.constants = constants
 
-    def dict_to_latex(self, term: dict, symbolic_constants: list, one_term: bool):
+        diff = len(self.constants) - len(self.variables)
+        alpha_id = [f'alpha_{idx}' for idx in range(diff)]
+        self.symbolic_constants = self.variables + alpha_id
+
+    def format_equation_term(self, term: dict, one_term: bool):
         """Given a dictionary it returns the symbolic equivalent. It drops all constants
         if it is just one term.
 
@@ -31,8 +35,6 @@ class Latex():
         ----------
         term : dict
             dictionary containing the information of the term
-        symbolic_constants : list
-            [description]
         one_term : bool
             True if it is the only term in the equation
 
@@ -47,7 +49,8 @@ class Latex():
         if one_term:
             coeff = ''
         else:
-            for cte, n in zip(symbolic_constants, term['constants']):
+            coeff = str(term['coefficient'])
+            for cte, n in zip(self.symbolic_constants, term['constants']):
                 if len(str(cte)) > 1:
                     if n == 1:
                         a += "\\" + str(cte)
@@ -58,7 +61,6 @@ class Latex():
                         a += str(cte)
                     if n > 1:
                         a += str(cte) + '^' + str(n)
-            coeff = str(term['coefficient'])
         D = self.format_derivatives(derivatives, variable)
         return coeff + a + D
 
@@ -71,7 +73,7 @@ class Latex():
             list of integers containing the order of the derivative with respect to the
             variable
         variable : str
-            variable to be differentiate
+            variable to be differentiated
 
         Returns
         -------
@@ -106,14 +108,10 @@ class Latex():
         str
             single string with all the equations typed in latex format
         """
-        diff = len(self.constants) - len(self.variables)
-        alpha_id = [f'alpha_{idx}' for idx in range(diff)]
-        symbolic_constants = self.variables + alpha_id
-
         latex_equation = ''
         one_term = (len(equation) == 1)
         for term in equation:
-            latex_equation += self.dict_to_latex(term, symbolic_constants, one_term) + '+'
+            latex_equation += self.format_equation_term(term, one_term) + '+'
         return latex_equation[:-1] + '=0'
 
     def format_determining_equations(self):
@@ -126,5 +124,6 @@ class Latex():
         """
         latex_system_of_eqns = ''
         for equation in self.determining_equations.values():
-            latex_system_of_eqns += self.format_equation(equation) + "\\" + "\\" + "\n"
+            latex_system_of_eqns += self.format_equation(
+                equation) + "\\" + "\\" + "\n"
         return latex_system_of_eqns

--- a/src/symmetries/utils/latex.py
+++ b/src/symmetries/utils/latex.py
@@ -97,21 +97,19 @@ def latex_eqn_code(eqn: dict, var_dict: dict, var_list: list, constants: list) -
     [string]
         single string with all the equations typed in latex format
     """
-    sym_cte_list = []
-    for idx in range(len(var_list)):
-        sym_cte_list.append(var_list[idx])
+
+    sym_cte_list = [var for var in var_list]
     for idx in range(len(constants) - len(var_list)):
         sym_cte_list.append('alpha_' + str(idx))
+
     A = ''
     for term in eqn:
         one_term = False
         if len(eqn) == 1:
             one_term = True
-        A = A + dict_to_latex(term, var_dict, var_list,
-                              sym_cte_list, one_term) + '+'
-    A = A[:-1]
-    A = A + '=0'
-    return A
+        A += dict_to_latex(term, var_dict, var_list,
+                           sym_cte_list, one_term) + '+'
+    return A[:-1] + '=0'
 
 
 def latex_det_eqn(det_eqn, var_dict, var_list, constants):

--- a/src/symmetries/utils/latex.py
+++ b/src/symmetries/utils/latex.py
@@ -25,7 +25,7 @@ class Latex():
 
         diff = len(self.constants) - len(self.variables)
         alpha_id = [f'alpha_{idx}' for idx in range(diff)]
-        self.symbolic_constants = constants+ self.variables + alpha_id
+        self.symbolic_constants = constants + self.variables + alpha_id
 
     def format_equation_term(self, term: dict, one_term: bool):
         """Given a dictionary it returns the symbolic equivalent. It drops all constants
@@ -87,13 +87,13 @@ class Latex():
                     if '_' in var_str:
                         var_str += "\\" + var
                     else:
-                        var_str += '_' + '{' + "\\" + var
+                        var_str += '_' + '{' + "\\" + var + '}'
                 else:
                     if '_' in var_str:
                         var_str += var
                     else:
-                        var_str += '_' + '{' + var
-        return var_str + '}'
+                        var_str += '_' + '{' + var + '}'
+        return var_str
 
     def format_equation(self, equation: dict) -> str:
         """This code generates the latex string format of the determinant equations

--- a/src/symmetries/utils/latex.py
+++ b/src/symmetries/utils/latex.py
@@ -1,19 +1,14 @@
-def dict_to_latex(term, var_dict, var_list, 
-                    sym_cte_list, one_term):
-    """Given a dictionary it returns the symbolic
-       equivalent. It drops all constants if it is 
-       just one term.
+def dict_to_latex(term, var_dict, var_list, sym_cte_list, one_term):
+    """Given a dictionary it returns the symbolic equivalent. It drops all constants if it is  just one term.
 
     Parameters
     ----------
     term : [dict]
         dictionary containing the information of the term
     var_dict : [dict]
-        dictionary translating the variable name to 
-        latex format
-    var_list : list with all variables (independant and 
-        dependant)
-        list with the constants writen in latex format
+        dictionary translating the variable name to latex format
+    var_list : [list]
+        list with all variables (independent and dependant)list with the constants written in latex format
     sym_cte_list : [list]
         [description]
     one_term : [boolean]
@@ -32,37 +27,33 @@ def dict_to_latex(term, var_dict, var_list,
         coeff = ''
     else:
         for cte, n in cte_power:
-            if len(str(cte))>1:
+            if len(str(cte)) > 1:
                 if n == 1:
                     a = a + "\\" + str(cte)
                 if n > 1:
-                    a = a + "\\" + str(cte) + '^' + str(n) 
+                    a = a + "\\" + str(cte) + '^' + str(n)
             else:
                 if n == 1:
                     a = a + str(cte)
                 if n > 1:
-                    a = a + str(cte) + '^' + str(n)           
+                    a = a + str(cte) + '^' + str(n)
         coeff = str(term['coefficient'])
     D = latex_derivative(list_devs, var, var_list)
     latex_term = coeff + a + D
     return latex_term
 
+
 def latex_derivative(list_devs, var, var_list):
-    """Given a list of derivatives executes all the
-       derivatives on the variable.
+    """Given a list of derivatives executes all the derivatives on the variable.
 
     Parameters
     ----------
     list_devs : [list]
-        list of ints containing the 
-        order of the derivative 
-        with respect to the variable
-        var_lists.
+        list of ints containing the order of the derivative with respect to the variable var_lists.
     var : [str]
         variable to be differentiate
     var_list : [list]
-        list of independant and dependant
-                          variables.
+        list of independant and dependant variables.
 
     Returns
     -------
@@ -73,9 +64,9 @@ def latex_derivative(list_devs, var, var_list):
     var_str = '\\' + var
     for D, v in D_v:
         for _ in range(D):
-            if len(str(v))>1:
+            if len(str(v)) > 1:
                 if '_' in var_str:
-                    var_str = var_str + "\\" +  v
+                    var_str = var_str + "\\" + v
                 else:
                     var_str = var_str + '_' + '{' + "\\" + v
             else:
@@ -86,28 +77,25 @@ def latex_derivative(list_devs, var, var_list):
     var = var_str + '}'
     return var
 
-def latex_eqn_code(eqn, var_dict, var_list, constants):
-    """This code generates the latex string format of 
-    the determinant equations
+
+def latex_eqn_code(eqn: dict, var_dict: dict, var_list: list, constants: list) -> str:
+    """This code generates the latex string format of the determinant equations
 
     Parameters
     ----------
     eqn : [dictionary]
-        dictionary containing all the determinant eqautions
+        dictionary containing all the determinant equations
     var_dict : [dictionary]
-        dictionary mapping the name of the variable to it's 
-        latex code 
+        dictionary mapping the name of the variable to its latex code
     var_list : [list]
-        list with all independant and dependant variables in
-        string format
+        list with all independent and dependant variables in string format
     constants : [list]
         list containing all constants
 
     Returns
     -------
     [string]
-        returns a single string with  all the equations 
-        typed in latex format
+        single string with all the equations typed in latex format
     """
     sym_cte_list = []
     for idx in range(len(var_list)):
@@ -120,22 +108,33 @@ def latex_eqn_code(eqn, var_dict, var_list, constants):
         if len(eqn) == 1:
             one_term = True
         A = A + dict_to_latex(term, var_dict, var_list,
-                                 sym_cte_list, one_term) + '+'
+                              sym_cte_list, one_term) + '+'
     A = A[:-1]
     A = A + '=0'
     return A
 
 
 def latex_det_eqn(det_eqn, var_dict, var_list, constants):
-    """Gives the latex code version of remaining
-       determining equation.
+    """Gives the latex code version of remaining determining equation.
 
-       Args:
-       det_eqn (dict): dictionary will all the
-                       determining equations. 
+    Parameters
+    ----------
+    det_eqn : [type]
+        [description
+    var_dict : [dictionary]
+        dictionary mapping the name of the variable to its latex code
+    var_list : [list]
+        list with all independent and dependant variables in string format
+    constants : [list]
+        list containing all constants
+
+    Returns
+    -------
+    [string]
+        single string with all the equations typed in latex format
     """
     latex_code = ''
     for eqn in det_eqn.values():
-        latex_code = latex_code + latex_eqn_code(eqn,
-                                                 var_dict, var_list, constants) + "\\" + "\\" + "\n"
+        latex_code += latex_eqn_code(eqn, var_dict, var_list, constants) + \
+            "\\" + "\\" + "\n"
     return latex_code

--- a/src/symmetries/utils/latex.py
+++ b/src/symmetries/utils/latex.py
@@ -1,138 +1,131 @@
-def dict_to_latex(term, var_dict, var_list, sym_cte_list, one_term):
-    """Given a dictionary it returns the symbolic equivalent. It drops all constants if it is  just one term.
-
-    Parameters
-    ----------
-    term : [dict]
-        dictionary containing the information of the term
-    var_dict : [dict]
-        dictionary translating the variable name to latex format
-    var_list : [list]
-        list with all variables (independent and dependant)list with the constants written in latex format
-    sym_cte_list : [list]
-        [description]
-    one_term : [boolean]
-        True if it is the only term in the equation
-
-    Returns
-    -------
-    [str]
-        The latex code to write the term. 
-    """
-    var = var_dict[term['variable']]
-    list_devs = term['derivatives']
-    cte_power = zip(sym_cte_list, term['constants'])
-    a = ''
-    if one_term:
-        coeff = ''
-    else:
-        for cte, n in cte_power:
-            if len(str(cte)) > 1:
-                if n == 1:
-                    a = a + "\\" + str(cte)
-                if n > 1:
-                    a = a + "\\" + str(cte) + '^' + str(n)
-            else:
-                if n == 1:
-                    a = a + str(cte)
-                if n > 1:
-                    a = a + str(cte) + '^' + str(n)
-        coeff = str(term['coefficient'])
-    D = latex_derivative(list_devs, var, var_list)
-    latex_term = coeff + a + D
-    return latex_term
+"""Module containing functions for printing in Latex form"""
 
 
-def latex_derivative(list_devs, var, var_list):
-    """Given a list of derivatives executes all the derivatives on the variable.
+class Latex():
 
-    Parameters
-    ----------
-    list_devs : [list]
-        list of ints containing the order of the derivative with respect to the variable var_lists.
-    var : [str]
-        variable to be differentiate
-    var_list : [list]
-        list of independant and dependant variables.
+    def __init__(self, det_eqn, var_dict: dict, var_list: list, constants: list):
+        """_summary_
 
-    Returns
-    -------
-    [str]
-        latex code for the derivative.
-    """
-    D_v = zip(list_devs, var_list)
-    var_str = '\\' + var
-    for D, v in D_v:
-        for _ in range(D):
-            if len(str(v)) > 1:
-                if '_' in var_str:
-                    var_str = var_str + "\\" + v
+        Parameters
+        ----------
+        det_eqn : _type_
+            _description_
+        var_dict : [dict]
+            dictionary translating the variable name to latex format
+        var_list : [list]
+            list with all variables (independent and dependant)list with the constants written in latex format
+        constants : [list]
+            list containing all constants
+        """
+        self.det_eqn = det_eqn
+        self.var_dict = var_dict
+        self.var_list = var_list
+        self.constants = constants
+
+    def dict_to_latex(self, term: dict, sym_cte_list: list, one_term: bool):
+        """Given a dictionary it returns the symbolic equivalent. It drops all constants if it is  just one term.
+
+        Parameters
+        ----------
+        term : [dict]
+            dictionary containing the information of the term
+        sym_cte_list : [list]
+            [description]
+        one_term : [boolean]
+            True if it is the only term in the equation
+
+        Returns
+        -------
+        [str]
+            The latex code to write the term. 
+        """
+        var = self.var_dict[term['variable']]
+        list_devs = term['derivatives']
+        cte_power = zip(sym_cte_list, term['constants'])
+        a = ''
+        if one_term:
+            coeff = ''
+        else:
+            for cte, n in cte_power:
+                if len(str(cte)) > 1:
+                    if n == 1:
+                        a += "\\" + str(cte)
+                    if n > 1:
+                        a += "\\" + str(cte) + '^' + str(n)
                 else:
-                    var_str = var_str + '_' + '{' + "\\" + v
-            else:
-                if '_' in var_str:
-                    var_str = var_str + v
+                    if n == 1:
+                        a += str(cte)
+                    if n > 1:
+                        a += str(cte) + '^' + str(n)
+            coeff = str(term['coefficient'])
+        D = self.latex_derivative(list_devs, var)
+        latex_term = coeff + a + D
+        return latex_term
+
+    def latex_derivative(self, list_devs: list, var: str):
+        """Given a list of derivatives executes all the derivatives on the variable.
+
+        Parameters
+        ----------
+        list_devs : [list]
+            list of ints containing the order of the derivative with respect to the variable var_lists.
+        var : [str]
+            variable to be differentiate
+
+        Returns
+        -------
+        [str]
+            latex code for the derivative.
+        """
+        D_v = zip(list_devs, self.var_list)
+        var_str = '\\' + var
+        for D, v in D_v:
+            for _ in range(D):
+                if len(str(v)) > 1:
+                    if '_' in var_str:
+                        var_str = var_str + "\\" + v
+                    else:
+                        var_str = var_str + '_' + '{' + "\\" + v
                 else:
-                    var_str = var_str + '_' + '{' + v
-    var = var_str + '}'
-    return var
+                    if '_' in var_str:
+                        var_str = var_str + v
+                    else:
+                        var_str = var_str + '_' + '{' + v
+        return var_str + '}'
 
+    def latex_eqn_code(self, eqn: dict) -> str:
+        """This code generates the latex string format of the determinant equations
 
-def latex_eqn_code(eqn: dict, var_dict: dict, var_list: list, constants: list) -> str:
-    """This code generates the latex string format of the determinant equations
+        Parameters
+        ----------
+        eqn : [dictionary]
+            dictionary containing all the determinant equations
 
-    Parameters
-    ----------
-    eqn : [dictionary]
-        dictionary containing all the determinant equations
-    var_dict : [dictionary]
-        dictionary mapping the name of the variable to its latex code
-    var_list : [list]
-        list with all independent and dependant variables in string format
-    constants : [list]
-        list containing all constants
+        Returns
+        -------
+        [string]
+            single string with all the equations typed in latex format
+        """
 
-    Returns
-    -------
-    [string]
-        single string with all the equations typed in latex format
-    """
+        sym_cte_list = [var for var in self.var_list]
+        for idx in range(len(self.constants) - len(self.var_list)):
+            sym_cte_list.append('alpha_' + str(idx))
 
-    sym_cte_list = [var for var in var_list]
-    for idx in range(len(constants) - len(var_list)):
-        sym_cte_list.append('alpha_' + str(idx))
+        A = ''
+        for term in eqn:
+            one_term = (len(eqn) == 1)
+            A += self.dict_to_latex(term, sym_cte_list, one_term) + '+'
+        return A[:-1] + '=0'
 
-    A = ''
-    for term in eqn:
-        one_term = False
-        if len(eqn) == 1:
-            one_term = True
-        A += dict_to_latex(term, var_dict, var_list,
-                           sym_cte_list, one_term) + '+'
-    return A[:-1] + '=0'
+    def latex_det_eqn(self):
+        """Gives the latex code version of remaining determining equation.
 
-
-def latex_det_eqn(det_eqn, var_dict, var_list, constants):
-    """Gives the latex code version of remaining determining equation.
-
-    Parameters
-    ----------
-    det_eqn : [type]
-        [description
-    var_dict : [dictionary]
-        dictionary mapping the name of the variable to its latex code
-    var_list : [list]
-        list with all independent and dependant variables in string format
-    constants : [list]
-        list containing all constants
-
-    Returns
-    -------
-    [string]
-        single string with all the equations typed in latex format
-    """
-    latex_code = ''
-    for eqn in det_eqn.values():
-        latex_code += latex_eqn_code(eqn, var_dict, var_list, constants) + \
-            "\\" + "\\" + "\n"
-    return latex_code
+        Returns
+        -------
+        [string]
+            single string with all the equations typed in latex format
+        """
+        latex_code = ''
+        for eqn in self.det_eqn.values():
+            latex_code += self.latex_eqn_code(eqn) + "\\" + "\\" + "\n"
+        return latex_code

--- a/src/symmetries/utils/symbolic.py
+++ b/src/symmetries/utils/symbolic.py
@@ -67,6 +67,7 @@ def take_derivative(dev_list, var_string, var_list):
             var_string += '_' + var
     return sympy.symbols(var_string)
 
+
 def Diff(f, y_var, x_var, order):
     dy = D(y_var, x_var).expand()
     Df = D(f, x_var).expand()
@@ -91,11 +92,10 @@ def sym_det_eqn(det_eqn, independent_variables, dependent_variables, constants):
     var_list = independent_variables + dependent_variables
 
     indep_var_str = [str(ele).replace(' ', '') for ele in independent_variables]
-    for dep_var in indep_var_str:
-        var = dep_var.split('(')[0]
+    for indep_var in indep_var_str:
+        var = indep_var.split('(')[0]
         if len(var) > 1:
-            var_dict[f'xi{var}'] = 'eta^' + \
-                '(' + "\\" + var + ')'
+            var_dict[f'xi{var}'] = 'xi^' + '(' + "\\" + var + ')'
         else:
             var_dict[f'xi{var}'] = f'xi^({var})'
 
@@ -103,16 +103,16 @@ def sym_det_eqn(det_eqn, independent_variables, dependent_variables, constants):
     for dep_var in dep_var_str:
         var = dep_var.split('(')[0]
         if len(var) > 1:
-            var_dict[f'eta{var}'] = 'eta^' + \
-                '(' + "\\" + var + ')'
+            var_dict[f'eta{var}'] = 'eta^' + '(' + "\\" + var + ')'
         else:
             var_dict[f'eta{var}'] = f'eta^({var})'
 
     matrix = sympy.Matrix([[]])
     for i, eqn in enumerate(det_eqn.values()):
         matrix = matrix.row_insert(i,
-        sympy.Matrix([[i, sympy.Eq(get_symbolic_terms(eqn, var_dict, constants, var_list), 0)]])
-        )
+                                   sympy.Matrix(
+                                       [[i, sympy.Eq(get_symbolic_terms(eqn, var_dict, constants, var_list), 0)]])
+                                   )
     return matrix
 
 
@@ -135,8 +135,9 @@ def get_symbolic_terms(eqn, var_dict, list_cte, var_list):
     for term in eqn:
         one_term = len(eqn) == 1
         a += dict_to_symb(term, var_dict, var_list,
-                             sym_cte_list, one_term)
+                          sym_cte_list, one_term)
     return a
+
 
 def parse_variables(independent_variables, dependent_variables):
     """Creates dictionary with translation to symbolic terms of variables.
@@ -149,7 +150,7 @@ def parse_variables(independent_variables, dependent_variables):
     var_dict = {}
 
     indep_var_str = [str(ele).replace(' ', '')
-                        for ele in independent_variables]
+                     for ele in independent_variables]
     for dep_var in indep_var_str:
         var = dep_var.split('(')[0]
         if len(var) > 1:
@@ -158,7 +159,7 @@ def parse_variables(independent_variables, dependent_variables):
             var_dict[f'xi{var}'] = f'xi^({var})'
 
     dep_var_str = [str(ele).replace(' ', '')
-                    for ele in dependent_variables]
+                   for ele in dependent_variables]
     for dep_var in dep_var_str:
         var = dep_var.split('(')[0]
         var_dict[f'eta{var}'] = f'eta^({var})'


### PR DESCRIPTION
- Turn print latex code into Latex class.
- Improve readability, docstrings, type hints. 
- Simplify logic to reduce complexity. 
- Replace variable and method names with descriptive names.

These changes make debugging easier. 
The main error was parsing equation terms, for example
{'coefficient': -1,
 'constants': [0, 0, 0, 0, 0, 0, 0, 1, 0, 0],
 'derivatives': [1, 0, 0, 0, 0, 0, 0, 0, 0],
 'variable': 'xit'}

According to the symbolic printing, the "constants" list was mapped incorrectly in the latex method. In the symbolic constants argument, it differed from the one in the _print_symbolic_equations method because it did not have the "constants" list added. 
I.e.
in get_symbolic_terms, sym_cte_list = list_cte + var_list
vs in latex printing, it only included the independent and dependent variables.